### PR TITLE
Fjerner konsument og endepunkt

### DIFF
--- a/api-gateway/oneshot.json
+++ b/api-gateway/oneshot.json
@@ -15,10 +15,6 @@
 	],
 	"konsumenter": [
 		{
-			"navn": "pleiepengesoknad-api",
-			"tjeneste": "helse-reverse-proxy"
-		},
-		{
 			"navn": "frisinn-api",
 			"tjeneste": "helse-reverse-proxy"
 		}

--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -37,8 +37,6 @@ spec:
   vault:
     enabled: false
   env:
-    - name: HRP_pleiepengesoknad_mottak
-      value: http://pleiepengesoknad-mottak
     - name: HRP_k9_selvbetjening_oppslag
       value: http://k9-selvbetjening-oppslag
     - name: HRP_frisinn_mottak

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -37,8 +37,6 @@ spec:
   vault:
     enabled: false
   env:
-    - name: HRP_pleiepengesoknad_mottak
-      value: http://pleiepengesoknad-mottak
     - name: HRP_k9_selvbetjening_oppslag
       value: http://k9-selvbetjening-oppslag
     - name: HRP_frisinn_mottak


### PR DESCRIPTION
Fjerner PP-api som konsument.
Fjerner apigw endepunkt til pp-mottak fordi PP-api kaller direkte med pub ingress.