### PR TITLE
Migrerer til namespace dusseldorf.

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -2,7 +2,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: helse-reverse-proxy
-  namespace: default
+  namespace: dusseldorf
   labels:
     team: dusseldorf
 spec:
@@ -38,8 +38,6 @@ spec:
     enabled: false
   env:
     - name: HRP_frisinn_mottak
-      value: http://frisinn-mottak.dusseldorf
-    - name: HRP_k9_dokument
-      value: http://k9-dokument.dusseldorf
+      value: http://frisinn-mottak
     - name: HRP_k9_selvbetjening_oppslag
-      value: http://k9-selvbetjening-oppslag.dusseldorf
+      value: http://k9-selvbetjening-oppslag

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -2,7 +2,7 @@ apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
   name: helse-reverse-proxy
-  namespace: default
+  namespace: dusseldorf
   labels:
     team: dusseldorf
 spec:
@@ -38,6 +38,6 @@ spec:
     enabled: false
   env:
     - name: HRP_frisinn_mottak
-      value: http://frisinn-mottak.dusseldorf
+      value: http://frisinn-mottak
     - name: HRP_k9_selvbetjening_oppslag
-      value: http://k9-selvbetjening-oppslag.dusseldorf
+      value: http://k9-selvbetjening-oppslag


### PR DESCRIPTION
Sletter k9-dokument oppføring i dev-fss da det ikke brukes.
Fjerner .dusseldorf suffix på value da alle appene vil nå være i samme namespace.